### PR TITLE
Fixing github links to point to new root

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -33,7 +33,7 @@
     <div class="sticky">
       <div class="github-fork-ribbon-wrapper right">
        <div class="github-fork-ribbon">
-           <a href="https://github.com/pixelated-project" target="_blank">Fork us on GitHub</a>
+           <a href="https://github.com/pixelated/" target="_blank">Fork us on GitHub</a>
        </div>
       </div>
       <nav class="top-bar" data-topbar role="navigation">

--- a/develop_pixelated.md
+++ b/develop_pixelated.md
@@ -28,7 +28,7 @@ Getting started
 
 >**Starting with the User Agent is probably a good idea.**
 
-* First create a fork of the <a href="https://github.com/pixelated-project/pixelated-user-agent">Pixelated User Agent repo</a> and clone it.
+* First create a fork of the <a href="https://github.com/pixelated/pixelated-user-agent">Pixelated User Agent repo</a> and clone it.
 
 * For a Quickstart, dependencies are: node, npm, ruby, bundle, virtualenv, git. Once you have that, from the root of the project run:
 
@@ -43,14 +43,14 @@ Getting started
   2. __A pixelated-user-agent service__
 * The Service component, which is the web service that serves the Web Ui to the browser, provides the REST API which the Web Ui uses, and integrates with the LEAP or Pixelated provider.
 
->**Hooked? For more detail on setting things up visit <a href= "https://github.com/pixelated-project/pixelated-user-agent">Github: Pixelated User Agent</a>**
+>**Hooked? For more detail on setting things up visit <a href= "https://github.com/pixelated/pixelated-user-agent">Github: Pixelated User Agent</a>**
 
 
 >### 2. Pixelated Dispatcher
 
 >**Or how to run multiple user agents on a server**
 
-* Here is where you can create a fork of the <a href="https://github.com/pixelated-project/pixelated-dispatcher">Pixelated-Dispatcher repo</a>.
+* Here is where you can create a fork of the <a href="https://github.com/pixelated/pixelated-dispatcher">Pixelated-Dispatcher repo</a>.
 
 * The pixelated-dispatcher allows you to run multiple instances of an application that had been designed for a single user, hence the name pixelated-dispatcher. Aside from managing the different instances it also provides a login form to restrict access to individual agents.
 
@@ -83,13 +83,13 @@ Getting started
     to isolate the agents from each other and to provide the necessary runtime environment.
 
 
->**To set up your full-fledged dispatcher development environment visit <a href="https://github.com/pixelated-project/pixelated-dispatcher">Github: pixelated-dispatcher.</a>**
+>**To set up your full-fledged dispatcher development environment visit <a href="https://github.com/pixelated/pixelated-dispatcher">Github: pixelated-dispatcher.</a>**
 
 
 >### 3. Pixelated Platform
 
 * It is the objective of the Pixelated Platform to provide a simple to install and maintain mail server based on the LEAP Platform.
 
-* Bear with us: we are not quite there, yet, with our Images. Stay tuned, there's more to come on <a href="https://github.com/pixelated-project/pixelated-platform">Github: pixelated-platform.</a>
+* Bear with us: we are not quite there, yet, with our Images. Stay tuned, there's more to come on <a href="https://github.com/pixelated/pixelated-platform">Github: pixelated-platform.</a>
 
 >**In the meantime we recommend checking out <a href="https://leap.se/en">the LEAP project</a>!**

--- a/getting-started.md
+++ b/getting-started.md
@@ -19,24 +19,24 @@ All you have to do is find a Pixelated provider:
 #### ACTIVISTS and other high-risk email users
 Do you want to use Pixelated but, due to your personal threat model, you are not comfortable with having your private key stored on the provider’s server?
 
-You need to install: <a target="_blank" href="https://github.com/pixelated-project/pixelated-user-agent">Pixelated User Agent</a>: run it on localhost and connect to your Pixelated Provider
+You need to install: <a target="_blank" href="https://github.com/pixelated/pixelated-user-agent">Pixelated User Agent</a>: run it on localhost and connect to your Pixelated Provider
 
 #### SYSADMINS or tech-savvy people
 
 Do you want to set up a Pixelated email provider for your friends, an organization, or something similar?
 
-You need to set up: <a target="_blank" href="https://github.com/pixelated-project/pixelated-platform">platform</a> (which brings along the <a target="_blank" href="https://github.com/pixelated-project/pixelated-dispatcher">dispatcher</a> and the <a target="_blank" href="https://github.com/pixelated-project/pixelated-user-agent">user agent</a> as a webmail interface)
+You need to set up: <a target="_blank" href="https://github.com/pixelated/pixelated-platform">platform</a> (which brings along the <a target="_blank" href="https://github.com/pixelated/pixelated-dispatcher">dispatcher</a> and the <a target="_blank" href="https://github.com/pixelated/pixelated-user-agent">user agent</a> as a webmail interface)
 
 #### DEVELOPERS and contributors
 
 You want to help develop the User Agent and always wanted to work with FlightJS or a Python Webapp?
-<a target="_blank" href="https://github.com/pixelated-project/pixelated-user-agent">Start here</a>
+<a target="_blank" href="https://github.com/pixelated/pixelated-user-agent">Start here</a>
 
 You want to help develop the Dispatcher, because you love Javascript and Python backend development?
-<a target="_blank" href="https://github.com/pixelated-project/pixelated-dispatcher">Start here</a>
+<a target="_blank" href="https://github.com/pixelated/pixelated-dispatcher">Start here</a>
 
 You want to help develop the Pixelated Platform and get all excited about infrastructure as code and Puppet?
-<a target="_blank" href="https://github.com/pixelated-project/pixelated-platform">Start here</a>
+<a target="_blank" href="https://github.com/pixelated/pixelated-platform">Start here</a>
 
 <br />
 

--- a/index.html
+++ b/index.html
@@ -1,7 +1,7 @@
 ---
 layout: default
---- 
-      
+---
+
   <section id="hive-section" class="guide-section no-padding" name="hive-section">
     <svg id="hive"></svg>
   </section>
@@ -47,7 +47,7 @@ layout: default
         </a>
       </li>
       <li>
-        <a href="https://github.com/pixelated-project">
+        <a href="https://github.com/pixelated/">
         <i class="fa fa-github"></i>
         <h3>Github</h3>
         Check out our repositories.
@@ -63,7 +63,7 @@ layout: default
            xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px" viewBox="49.2 658.2 612 140"
            enable-background="new 49.2 658.2 612 140" xml:space="preserve">
           <rect x="173.9" y="658.2" fill="#FD890A" width="362.4" height="140"/>
-          
+
           <a xlink:href="https://leap.se/en/docs/platform" target="_blank">
             <g id="leap" class="clickable-section">
               <rect class="clickable-section-bg" x="418.2" y="690.1" fill="#FDAB3D" width="118.3" height="108.1"/>
@@ -85,7 +85,7 @@ layout: default
           <text transform="matrix(1 0 0 1 569.3808 679.0674)" fill="#FFFFFF" $navigation_background: font-size="12.7197">Destination</text>
           <circle fill="#197994" cx="602.1" cy="719.3" r="21.7"/>
           <text transform="matrix(1 0 0 1 590.248 728.2988)" fill="#FFFFFF" font-family="'FontAwesome'" font-size="25.4394"></text>
-          
+
           <a xlink:href="#" data-reveal-id="dispatcher-modal" target="_blank">
             <g id="dispatcher" class="clickable-section">
               <rect class="clickable-section-bg" x="173.9" y="690.1" fill="#FDAB3D" width="118.3" height="108.1"/>
@@ -99,7 +99,7 @@ layout: default
           <rect x="127.6" y="712.3" fill="#197994" width="65.8" height="12.7"/>
           <text transform="matrix(1 0 0 1 148.5542 721.9014)" fill="#FFFFFF" $navigation_background: font-size="8.177">HTTPS</text>
           <path fill="#FD890A" d="M315.4,707.6l10.8,11.5l-10.8,11.5V707.6z"/>
-          
+
           <a xlink:href="#" data-reveal-id="user-agent-modal" target="_blank">
             <g id="user-agent" class="clickable-section">
               <rect class="clickable-section-bg" x="296.1" y="690.1" fill="#FDAB3D" width="118.3" height="108.1"/>
@@ -112,7 +112,7 @@ layout: default
 
           <rect x="250.5" y="712.3" fill="#FD890A" width="65.8" height="12.7"/>
           <path fill="#FD890A" d="M440,707.6l10.8,11.5L440,730.7V707.6z"/>
-          
+
 
           <a xlink:href="https://leap.se/en/docs/design/soledad" target="_blank">
             <g id="soledad" class="clickable-section">
@@ -128,7 +128,7 @@ layout: default
           <text transform="matrix(1 0 0 1 517.371 721.4102)" fill="#FFFFFF" $navigation_background: font-size="8.177">SMTP(S)</text>
           <path fill="#197994" d="M193.4,706.6l10.8,11.5l-10.8,11.6V706.6z"/>
           <path fill="#FD890A" d="M315.8,707.2l10.8,11.5l-10.8,11.5V707.2z"/>
-          
+
           <a xlink:href="#" data-reveal-id="platform-modal" target="_blank">
             <g id="platform" class="clickable-section">
               <rect class="clickable-section-bg" x="173.9" y="658.2" fill="#FD890A" width="362.5" height="31.9"/>
@@ -140,21 +140,21 @@ layout: default
       <div id="dispatcher-modal" class="reveal-modal" data-reveal>
         <h2>PIXELATED DISPATCHER</h2>
         <img src="/assets/images/pixelated-dispatcher.png">
-        <a href="https://github.com/pixelated-project/pixelated-dispatcher" target="_blank">Learn more about the Pixelated dispatcher with our documentation on Github</a>
+        <a href="https://github.com/pixelated/pixelated-dispatcher" target="_blank">Learn more about the Pixelated dispatcher with our documentation on Github</a>
         <a class="close-reveal-modal">&#215;</a>
       </div>
 
       <div id="user-agent-modal" class="reveal-modal" data-reveal>
         <h2>PIXELATED USER AGENT</h2>
         <img src="/assets/images/pixelated-user-agent.png">
-        <a href="https://github.com/pixelated-project/pixelated-user-agent" target="_blank">Learn more about the Pixelated user agent with our documentation on Github</a>
+        <a href="https://github.com/pixelated/pixelated-user-agent" target="_blank">Learn more about the Pixelated user agent with our documentation on Github</a>
         <a class="close-reveal-modal">&#215;</a>
       </div>
 
       <div id="platform-modal" class="reveal-modal" data-reveal>
         <h2>PIXELATED PLATFORM</h2>
         <img src="/assets/images/pixelated-platform.png">
-        <a href="https://github.com/pixelated-project/pixelated-platform" target="_blank">Learn more about the Pixelated platform with our documentation on Github</a>
+        <a href="https://github.com/pixelated/pixelated-platform" target="_blank">Learn more about the Pixelated platform with our documentation on Github</a>
         <a class="close-reveal-modal">&#215;</a>
       </div>
       </li>


### PR DESCRIPTION
I noticed that all the github links still point to the old root project of "pixelated-project", I've updated them to point to the new root of "pixelated".